### PR TITLE
fix: add repository of webp-convert dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,10 @@
     {
       "type": "vcs",
       "url": "https://github.com/S1SYPHOS/webp-convert"
+    },
+    {
+      "type": "vcs",
+      "url": "https://github.com/rosell-dk/webp-convert"
     }
   ],
   "require": {

--- a/composer.json
+++ b/composer.json
@@ -1,14 +1,11 @@
 {
   "name": "s1syphos/kirby-webp",
   "type": "kirby-plugin",
+  "minimum-stability": "dev",
   "repositories": [
     {
       "type": "vcs",
       "url": "https://github.com/S1SYPHOS/webp-convert"
-    },
-    {
-      "type": "vcs",
-      "url": "https://github.com/rosell-dk/webp-convert"
     }
   ],
   "require": {


### PR DESCRIPTION
as webp-convert is not registered on packagist we have to add it manually

https://getcomposer.org/doc/05-repositories.md#loading-a-package-from-a-vcs-repository